### PR TITLE
feat: Update translation script to run status check on final commit of PR

### DIFF
--- a/transifex/utils.py
+++ b/transifex/utils.py
@@ -345,7 +345,7 @@ class Repo:
 
     def _get_tests_combined_status(self):
         """ Returns combined status of pr tests """
-        commit = self.pr.get_commits()[0]
+        commit = self.pr.get_commits()[-1]
         combined_statuses = commit.get_combined_status()
         if combined_statuses.total_count > 0:
             return combined_statuses.state


### PR DESCRIPTION
The translations script generates a PR with a diff with updated internationalized strings. The script then checks to make sure the PR has passed all status checks. If status checks have passed, it then merges the PR into the repo.  If they have failed, the PR is closed.

Prospectus was running into an issue where, because we now have multiple PRs merging in the mornings when our translations PR merges, the translations PR would fail status check due to getting out of sync with master. We implemented a bot that automatically updates translations PRs to stay in sync with master.  However, we found that the translations PR would still fail, because the status check is only run for the first commit.

This PR changes the status check to run on the last commit. We believe this will not affect other repos that use the translations job.  In most cases, the last commit will be the same as the first commit.