### PR TITLE
build: add file for missing ora2 library permissions

### DIFF
--- a/transifex/requirements/edx-ora2.txt
+++ b/transifex/requirements/edx-ora2.txt
@@ -1,0 +1,5 @@
+-r ./edx-platform.txt
+
+django-waffle==2.3.0
+xblock-sdk==0.4.0
+edx-submissions==3.5.1

--- a/transifex/requirements/edx-platform.txt
+++ b/transifex/requirements/edx-platform.txt
@@ -9,7 +9,7 @@ PyGithub==1.53
 transifex-client==0.12.4
 
 # third-party
-edx-proctoring-proctortrack==1.0.1
+edx-proctoring-proctortrack==1.1.0
 
 # third-party Python libraries to be installed directly from github
 git+https://github.com/edx/django-wiki.git@0.1.1#egg=django-wiki


### PR DESCRIPTION
following the pattern of how edx-proctoring is set up, motivated by an
error like `ModuleNotFoundError: No module named 'waffle'`

also tangentially updates the version of a library I'm concerned with to latest, which may impact translations done by this & other plugins

downstream: https://github.com/edx/edx-internal/pull/6359