### PR TITLE
fix: manually update lazy version to 1.4 to fix "use_2to3 is invalid" error

### DIFF
--- a/transifex/requirements/edx-platform.txt
+++ b/transifex/requirements/edx-platform.txt
@@ -20,7 +20,7 @@ certifi==2019.11.28       # via requests
 chardet==3.0.4            # via requests
 edx-opaque-keys==2.0.1
 idna==2.8                 # via requests
-lazy==1.1
+lazy==1.4
 markupsafe==1.1.1
 mock==3.0.5
 path.py==8.2.1


### PR DESCRIPTION
edx-proctoring-pull_translations jobs are failing with the error "error in lazy setup command: use_2to3 is invalid."

The currently installed version of the lazy library, 1.1, uses the use_2to3 library. Version 1.3 of the lazy library add support for Python 2.6-3.6 without the 2to3 library. This pull requests bumps the version of the lazy library to 1.4, which is the most recent release of this library.

This error occurs when the version of setuptools is upgraded from a version less than 58 to a version greater than or equal to 58. Version 58 of setuptools dropped support for the "use_2to3" directive. However, many runs of the edx-proctoring-pull_translations job have run successfully with a version of setuptools greater than 60.

I am not entirely sure what the underlying issue is, but upgrading the lazy library will fix this error.