### PR TITLE
fix: remove python transifex client from requirements

### DIFF
--- a/transifex/requirements.txt
+++ b/transifex/requirements.txt
@@ -3,4 +3,3 @@ Django==2.2.20
 edx-i18n-tools==0.5.3
 PyGithub==1.53
 PyYAML==5.4
-transifex-client==0.12.4

--- a/transifex/requirements/edx-mktg.txt
+++ b/transifex/requirements/edx-mktg.txt
@@ -3,7 +3,6 @@ Django==2.2.20
 edx-i18n-tools==0.4.5
 PyGithub==1.53
 PyYAML==5.4
-transifex-client==0.12.4
 
 # edx-mktg requirements
 babel==2.5.3

--- a/transifex/requirements/edx-platform.txt
+++ b/transifex/requirements/edx-platform.txt
@@ -6,7 +6,6 @@ enmerkar==0.7.1
 mako==1.0.7
 markey==0.8
 PyGithub==1.53
-transifex-client==0.12.4
 
 # third-party
 edx-proctoring-proctortrack==1.1.0


### PR DESCRIPTION
### Description
- The translation job has been updated to install the new `Go Transifex Client` when running Transifex commands so removing the old unsupported `Python Client` from Transifex Requirements.