### PR TITLE
fix: avoid use of use_2to3 in PyGithub setup.py for geoip job

### DIFF
--- a/geoipupdate/requirements.txt
+++ b/geoipupdate/requirements.txt
@@ -1,4 +1,4 @@
-PyGithub==1.43.3
+PyGithub==1.44.1
 urllib3==1.24.1
 testfixtures
 pytest


### PR DESCRIPTION
error message like 
<img width="689" alt="Screenshot 2023-03-30 at 11 33 02 AM" src="https://user-images.githubusercontent.com/6405097/228888234-868f3134-9b42-4ef6-8055-18f031d7cf7e.png">

which from https://github.com/PyGithub/PyGithub/commit/fec6034a07677b9978a605dc72ab601f6cd1c1b3#diff-60f61ab7a8d1910d86d9fda2261620314edcae5894d5aaa236b821c7256badd7L112 was addressed in 1.44.1

the feature in question is a setup.py which is effectively not maintained for backwards compatibility